### PR TITLE
hotfix: development environment hot reload fix

### DIFF
--- a/api/Dockerfile.dev
+++ b/api/Dockerfile.dev
@@ -18,6 +18,4 @@ RUN pip install -r requirements.txt
 EXPOSE 5001
 
 # run the flask development server
-ENTRYPOINT [ "python" ]
-
-CMD [ "app.py" ]
+CMD [ "flask", "run", "--host=0.0.0.0", "--port=5001"]

--- a/api/app.py
+++ b/api/app.py
@@ -5,13 +5,6 @@ from worker import celery
 
 dev_mode = True
 app = Flask(__name__)
-app.config.update(
-    TESTING=dev_mode,
-    DEBUG=dev_mode,
-    USE_RELOADER=dev_mode,
-    THREADED=False
-)
-
 
 @app.route('/add/<int:param1>/<int:param2>')
 def add(param1: int, param2: int) -> str:

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -4,10 +4,6 @@ services:
     build:
       context: ./api
       dockerfile: Dockerfile.dev
-    entrypoint:
-      - flask
-      - run
-      - --host=0.0.0.0
     environment:
       FLASK_DEBUG: "on"
       FLASK_APP: ./app.py

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -4,6 +4,13 @@ services:
     build:
       context: ./api
       dockerfile: Dockerfile.dev
+    entrypoint:
+      - flask
+      - run
+      - --host=0.0.0.0
+    environment:
+      FLASK_DEBUG: "on"
+      FLASK_APP: ./app.py
     restart: always
     ports:
      - "5001:5001"


### PR DESCRIPTION
<!-- Describe your Pull Request -->
This PR enable hot reload using docker compose file. The current implement run Flask in production mode and the following exception is thrown.

```
web_1    |  * Running on http://0.0.0.0:5001/ (Press CTRL+C to quit)
web_1    |  * Serving Flask app "app" (lazy loading)
web_1    |  * Environment: production
web_1    |    WARNING: Do not use the development server in a production environment.
web_1    |    Use a production WSGI server instead.
web_1    |  * Debug mode: on
web_1    |  * Restarting with stat
web_1    | Traceback (most recent call last):
web_1    |   File "app.py", line 38, in <module>
web_1    |     app.run(host='0.0.0.0', port='5001')
web_1    |   File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 943, in run
web_1    |     run_simple(host, port, self, **options)
web_1    |   File "/usr/local/lib/python3.6/site-packages/werkzeug/serving.py", line 1007, in run_simple
web_1    |     run_with_reloader(inner, extra_files, reloader_interval, reloader_type)
web_1    |   File "/usr/local/lib/python3.6/site-packages/werkzeug/_reloader.py", line 332, in run_with_reloader
web_1    |     sys.exit(reloader.restart_with_reloader())
web_1    |   File "/usr/local/lib/python3.6/site-packages/werkzeug/_reloader.py", line 176, in restart_with_reloader
web_1    |     exit_code = subprocess.call(args, env=new_environ, close_fds=False)
web_1    |   File "/usr/local/lib/python3.6/subprocess.py", line 287, in call
web_1    |     with Popen(*popenargs, **kwargs) as p:
web_1    |   File "/usr/local/lib/python3.6/subprocess.py", line 729, in __init__
web_1    |     restore_signals, start_new_session)
web_1    |   File "/usr/local/lib/python3.6/subprocess.py", line 1364, in _execute_child
web_1    |     raise child_exception_type(errno_num, err_msg, err_filename)
web_1    | PermissionError: [Errno 13] Permission denied: '/api/app.py'
```

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
